### PR TITLE
[ODPR-1773] - Add email sent/not sent content to Update & Remove PO

### DIFF
--- a/app/controllers/update/PlatformOperatorUpdatedController.scala
+++ b/app/controllers/update/PlatformOperatorUpdatedController.scala
@@ -16,15 +16,20 @@
 
 package controllers.update
 
+import connectors.SubscriptionConnector
+import controllers.AnswerExtractor
 import controllers.actions._
+import models.email.EmailsSentResult
+import models.pageviews.PlatformOperatorUpdatedViewModel
 import pages.add.{BusinessNamePage, PrimaryContactEmailPage}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import queries.SentUpdatedPlatformOperatorEmailQuery
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import viewmodels.PlatformOperatorSummaryViewModel
 import views.html.update.PlatformOperatorUpdatedView
 
 import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
 
 class PlatformOperatorUpdatedController @Inject()(
                                                    override val messagesApi: MessagesApi,
@@ -32,16 +37,23 @@ class PlatformOperatorUpdatedController @Inject()(
                                                    getData: DataRetrievalActionProvider,
                                                    requireData: DataRequiredAction,
                                                    val controllerComponents: MessagesControllerComponents,
-                                                   view: PlatformOperatorUpdatedView
-                                                 )
-  extends FrontendBaseController with I18nSupport {
+                                                   view: PlatformOperatorUpdatedView,
+                                                   connector: SubscriptionConnector
+                                                 )(implicit executionContext: ExecutionContext)
+  extends FrontendBaseController with I18nSupport with AnswerExtractor {
 
-  def onPageLoad(operatorId: String): Action[AnyContent] = (identify andThen getData(Some(operatorId)) andThen requireData) { implicit request =>
+  def onPageLoad(operatorId: String): Action[AnyContent] = (identify andThen getData(Some(operatorId)) andThen requireData).async { implicit request =>
     request.userAnswers.get(BusinessNamePage).map { businessName =>
-      val viewModel = PlatformOperatorSummaryViewModel(operatorId, businessName, request.userAnswers.get(PrimaryContactEmailPage).toString)
-      Ok(view(operatorId, viewModel))
+      val emailsSentResult = request.userAnswers.get(SentUpdatedPlatformOperatorEmailQuery).getOrElse(EmailsSentResult(userEmailSent = false, None))
+      request.userAnswers.get(PrimaryContactEmailPage).map { poEmail =>
+        connector.getSubscriptionInfo.map { x =>
+          Ok(view(PlatformOperatorUpdatedViewModel(x.primaryContact.email, operatorId, businessName, poEmail, emailsSentResult)))
+        }
+      }.getOrElse {
+        Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
+      }
     }.getOrElse {
-      Redirect(controllers.routes.JourneyRecoveryController.onPageLoad())
+      Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
     }
   }
 }

--- a/app/controllers/update/PlatformOperatorUpdatedController.scala
+++ b/app/controllers/update/PlatformOperatorUpdatedController.scala
@@ -45,12 +45,10 @@ class PlatformOperatorUpdatedController @Inject()(
   def onPageLoad(operatorId: String): Action[AnyContent] = (identify andThen getData(Some(operatorId)) andThen requireData).async { implicit request =>
     request.userAnswers.get(BusinessNamePage).map { businessName =>
       val emailsSentResult = request.userAnswers.get(SentUpdatedPlatformOperatorEmailQuery).getOrElse(EmailsSentResult(userEmailSent = false, None))
-      request.userAnswers.get(PrimaryContactEmailPage).map { poEmail =>
-        connector.getSubscriptionInfo.map { x =>
-          Ok(view(PlatformOperatorUpdatedViewModel(x.primaryContact.email, operatorId, businessName, poEmail, emailsSentResult)))
-        }
-      }.getOrElse {
-        Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
+      val poEmail = request.userAnswers.get(PrimaryContactEmailPage).get
+
+      connector.getSubscriptionInfo.map { x =>
+        Ok(view(PlatformOperatorUpdatedViewModel(x.primaryContact.email, operatorId, businessName, poEmail, emailsSentResult)))
       }
     }.getOrElse {
       Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))

--- a/app/models/pageviews/PlatformOperatorRemovedViewModel.scala
+++ b/app/models/pageviews/PlatformOperatorRemovedViewModel.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.pageviews
+
+import models.email.EmailsSentResult
+import models.subscription.SubscriptionInfo
+import viewmodels.PlatformOperatorSummaryViewModel
+
+case class PlatformOperatorRemovedViewModel(userEmail: String,
+                                            operatorId: String,
+                                            poBusinessName: String,
+                                            poEmail: String,
+                                            emailsSentResult: EmailsSentResult) {
+
+  lazy val sentEmails: Seq[String] = Seq(
+    if (emailsSentResult.userEmailSent) Some(userEmail) else None,
+    emailsSentResult.poEmailSent.filter(identity).map(_ => poEmail)
+  ).flatten
+}
+
+object PlatformOperatorRemovedViewModel {
+
+  def apply(subscriptionInfo: SubscriptionInfo,
+            platformOperatorSummaryViewModel: PlatformOperatorSummaryViewModel,
+            emailsSentResult: EmailsSentResult): PlatformOperatorRemovedViewModel = PlatformOperatorRemovedViewModel(
+    userEmail = subscriptionInfo.primaryContact.email,
+    operatorId = platformOperatorSummaryViewModel.operatorId,
+    poBusinessName = platformOperatorSummaryViewModel.operatorName,
+    poEmail = platformOperatorSummaryViewModel.poPrimaryContactEmail,
+    emailsSentResult = emailsSentResult
+  )
+}

--- a/app/models/pageviews/PlatformOperatorUpdatedViewModel.scala
+++ b/app/models/pageviews/PlatformOperatorUpdatedViewModel.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.pageviews
+
+import models.email.EmailsSentResult
+import models.subscription.SubscriptionInfo
+import viewmodels.PlatformOperatorSummaryViewModel
+
+case class PlatformOperatorUpdatedViewModel(userEmail: String,
+                                            operatorId: String,
+                                            poBusinessName: String,
+                                            poEmail: String,
+                                            emailsSentResult: EmailsSentResult) {
+
+  lazy val sentEmails: Seq[String] = Seq(
+    if (emailsSentResult.userEmailSent) Some(userEmail) else None,
+    emailsSentResult.poEmailSent.filter(identity).map(_ => poEmail)
+  ).flatten
+}
+
+object PlatformOperatorUpdatedViewModel {
+
+  def apply(subscriptionInfo: SubscriptionInfo,
+            platformOperatorSummaryViewModel: PlatformOperatorSummaryViewModel,
+            emailsSentResult: EmailsSentResult): PlatformOperatorUpdatedViewModel = PlatformOperatorUpdatedViewModel(
+    userEmail = subscriptionInfo.primaryContact.email,
+    operatorId = platformOperatorSummaryViewModel.operatorId,
+    poBusinessName = platformOperatorSummaryViewModel.operatorName,
+    poEmail = platformOperatorSummaryViewModel.poPrimaryContactEmail,
+    emailsSentResult = emailsSentResult
+  )
+}

--- a/app/queries/SentRemovedPlatformOperatorEmailQuery.scala
+++ b/app/queries/SentRemovedPlatformOperatorEmailQuery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,9 @@
 
 package queries
 
+import models.email.EmailsSentResult
 import play.api.libs.json.JsPath
-import viewmodels.PlatformOperatorSummaryViewModel
 
-case object PlatformOperatorDeletedQuery extends Gettable[PlatformOperatorSummaryViewModel] with Settable[PlatformOperatorSummaryViewModel] {
-
-  override def path: JsPath = JsPath \ "platformOperatorDeletedInfo"
+case object SentRemovedPlatformOperatorEmailQuery extends Gettable[EmailsSentResult] with Settable[EmailsSentResult] {
+  override def path: JsPath = JsPath \ "sentRemovedPlatformOperatorEmail"
 }

--- a/app/queries/SentUpdatedPlatformOperatorEmailQuery.scala
+++ b/app/queries/SentUpdatedPlatformOperatorEmailQuery.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package queries
+
+import models.email.EmailsSentResult
+import play.api.libs.json.JsPath
+
+case object SentUpdatedPlatformOperatorEmailQuery extends Gettable[EmailsSentResult] with Settable[EmailsSentResult] {
+  override def path: JsPath = JsPath \ "sentUpdatedPlatformOperatorEmail"
+}

--- a/app/views/update/PlatformOperatorRemovedView.scala.html
+++ b/app/views/update/PlatformOperatorRemovedView.scala.html
@@ -15,16 +15,38 @@
  *@
 
 @import controllers.routes
+@import models.email.EmailsSentResult
+@import models.pageviews.PlatformOperatorRemovedViewModel
 
 @this(
-        layout: templates.Layout
+        layout: templates.Layout,
+        govukWarning: GovukWarningText
 )
 
-@(operatorId: String, businessName: String)(implicit request: Request[_], messages: Messages)
+@(viewModel: PlatformOperatorRemovedViewModel)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("platformOperatorRemoved.title")), showBackLink = false) {
 
-    <h1 class="govuk-heading-xl">@messages("platformOperatorRemoved.heading", businessName, operatorId)</h1>
+    <h1 class="govuk-heading-xl">@messages("platformOperatorRemoved.heading", viewModel.poBusinessName, viewModel.operatorId)</h1>
+
+    <p class="govuk-body">
+        @if(viewModel.sentEmails.size == 2) {
+            @messages("platformOperatorRemoved.p1.1.two.emails", viewModel.userEmail, viewModel.poEmail)
+        } else if(viewModel.sentEmails.size == 1) {
+            @messages("platformOperatorRemoved.p1.1.one.email", viewModel.sentEmails.head)
+        }
+    </p>
+
+    @if(viewModel.sentEmails.size == 0) {
+        @govukWarning(WarningText(
+            iconFallbackText = Some("Warning"),
+        content = messages("platformOperatorRemoved.emailNotSent.warning")
+        ))
+
+        <p id="print-this-page" class="govuk-list govuk-link print-link hmrc-!-js-visible govuk-!-display-none-print">
+            <a class="govuk-link hmrc-!-js-visible" data-module="hmrc-print-link" href="#" >@messages("platformOperatorRemoved.print.link.text")</a>
+        </p>
+    }
 
     <p class="govuk-body">
         <a href="@routes.PlatformOperatorsController.onPageLoad" class="govuk-button">@messages("platformOperatorRemoved.button")</a>

--- a/app/views/update/PlatformOperatorRemovedView.scala.html
+++ b/app/views/update/PlatformOperatorRemovedView.scala.html
@@ -44,7 +44,7 @@
         ))
 
         <p id="print-this-page" class="govuk-list govuk-link print-link hmrc-!-js-visible govuk-!-display-none-print">
-            <a class="govuk-link hmrc-!-js-visible" data-module="hmrc-print-link" href="#" >@messages("platformOperatorRemoved.print.link.text")</a>
+            <a class="govuk-link hmrc-!-js-visible" data-module="hmrc-print-link" href="#" >@messages("site.printThisPage")</a>
         </p>
     }
 

--- a/app/views/update/PlatformOperatorUpdatedView.scala.html
+++ b/app/views/update/PlatformOperatorUpdatedView.scala.html
@@ -52,7 +52,7 @@
             ))
 
             <p id="print-this-page" class="govuk-list govuk-link print-link hmrc-!-js-visible govuk-!-display-none-print">
-                <a class="govuk-link hmrc-!-js-visible" data-module="hmrc-print-link" href="#" >@messages("platformOperatorUpdated.print.link.text")</a>
+                <a class="govuk-link hmrc-!-js-visible" data-module="hmrc-print-link" href="#" >@messages("site.printThisPage")</a>
             </p>
         }
 

--- a/app/views/update/PlatformOperatorUpdatedView.scala.html
+++ b/app/views/update/PlatformOperatorUpdatedView.scala.html
@@ -16,15 +16,17 @@
 
 @import config.FrontendAppConfig
 @import controllers.routes
-@import viewmodels.PlatformOperatorSummaryViewModel
+@import models.email.EmailsSentResult
+@import models.pageviews.PlatformOperatorUpdatedViewModel
 
 @this(
         layout: templates.Layout,
         govukPanel: GovukPanel,
+        govukWarning: GovukWarningText,
         appConfig: FrontendAppConfig
 )
 
-@(operatorId: String, viewModel: PlatformOperatorSummaryViewModel)(implicit request: Request[_], messages: Messages)
+@(viewModel: PlatformOperatorUpdatedViewModel)(implicit request: Request[_], messages: Messages)
 
 @layout(
     pageTitle = titleNoForm(messages("platformOperatorUpdated.title")),
@@ -32,8 +34,28 @@
 ) {
 
     @govukPanel(Panel(
-        title = messages("platformOperatorUpdated.panel.heading", viewModel.operatorName)
+        title = messages("platformOperatorUpdated.panel.heading", viewModel.poBusinessName)
     ))
+
+        <p class="govuk-body">
+            @if(viewModel.sentEmails.size == 2) {
+                @messages("platformOperatorUpdated.p1.1.two.emails", viewModel.userEmail, viewModel.poEmail)
+            } else if(viewModel.sentEmails.size == 1) {
+                @messages("platformOperatorUpdated.p1.1.one.email", viewModel.sentEmails.head)
+            }
+        </p>
+
+        @if(viewModel.sentEmails.size == 0) {
+            @govukWarning(WarningText(
+                iconFallbackText = Some("Warning"),
+                content = messages("platformOperatorUpdated.emailNotSent.warning")
+            ))
+
+            <p id="print-this-page" class="govuk-list govuk-link print-link hmrc-!-js-visible govuk-!-display-none-print">
+                <a class="govuk-link hmrc-!-js-visible" data-module="hmrc-print-link" href="#" >@messages("platformOperatorUpdated.print.link.text")</a>
+            </p>
+        }
+
 
     <p class="govuk-body">
         <a href="@routes.PlatformOperatorsController.onPageLoad" class="govuk-link">@messages("platformOperatorUpdated.link1.text")</a>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -327,7 +327,6 @@ platformOperatorUpdated.link2.text = Return to manage your digital platform repo
 platformOperatorUpdated.p1.1.two.emails = We have sent a confirmation email to {0} and {1}.
 platformOperatorUpdated.p1.1.one.email = We have sent a confirmation email to {0}.
 platformOperatorUpdated.emailNotSent.warning = You will not be emailed a confirmation of this.
-platformOperatorUpdated.print.link.text = Print this page
 
 platformOperatorAdded.title = Platform operator added
 platformOperatorAdded.panel.heading = {0} added
@@ -385,7 +384,6 @@ platformOperatorRemoved.button = Return to view platform operators
 platformOperatorRemoved.p1.1.two.emails = We have sent a confirmation email to {0} and {1}.
 platformOperatorRemoved.p1.1.one.email = We have sent a confirmation email to {0}.
 platformOperatorRemoved.emailNotSent.warning = You will not be emailed a confirmation of this.
-platformOperatorRemoved.print.link.text = Print this page
 
 addGuidance.title = Add a reporting notification
 addGuidance.heading = Add a reporting notification

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -324,6 +324,10 @@ platformOperatorUpdated.title = Platform operator updated
 platformOperatorUpdated.panel.heading = Details updated for {0}
 platformOperatorUpdated.link1.text = Return to view your platform operators
 platformOperatorUpdated.link2.text = Return to manage your digital platform reporting
+platformOperatorUpdated.p1.1.two.emails = We have sent a confirmation email to {0} and {1}.
+platformOperatorUpdated.p1.1.one.email = We have sent a confirmation email to {0}.
+platformOperatorUpdated.emailNotSent.warning = You will not be emailed a confirmation of this.
+platformOperatorUpdated.print.link.text = Print this page
 
 platformOperatorAdded.title = Platform operator added
 platformOperatorAdded.panel.heading = {0} added

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -381,7 +381,7 @@ removePlatformOperator.error.required = Select yes if you want to remove {0}
 
 platformOperatorRemoved.title = Platform operator has been successfully removed
 platformOperatorRemoved.heading = {0} (PO {1}) has been successfully removed
-platformOperatorRemoved.button = Back to view platform operators
+platformOperatorRemoved.button = Return to view platform operators
 platformOperatorRemoved.p1.1.two.emails = We have sent a confirmation email to {0} and {1}.
 platformOperatorRemoved.p1.1.one.email = We have sent a confirmation email to {0}.
 platformOperatorRemoved.emailNotSent.warning = You will not be emailed a confirmation of this.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -382,6 +382,10 @@ removePlatformOperator.error.required = Select yes if you want to remove {0}
 platformOperatorRemoved.title = Platform operator has been successfully removed
 platformOperatorRemoved.heading = {0} (PO {1}) has been successfully removed
 platformOperatorRemoved.button = Back to view platform operators
+platformOperatorRemoved.p1.1.two.emails = We have sent a confirmation email to {0} and {1}.
+platformOperatorRemoved.p1.1.one.email = We have sent a confirmation email to {0}.
+platformOperatorRemoved.emailNotSent.warning = You will not be emailed a confirmation of this.
+platformOperatorRemoved.print.link.text = Print this page
 
 addGuidance.title = Add a reporting notification
 addGuidance.heading = Add a reporting notification

--- a/test-utils/builders/PlatformOperatorRemovedViewModelBuilder.scala
+++ b/test-utils/builders/PlatformOperatorRemovedViewModelBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 
-package queries
+package builders
 
-import play.api.libs.json.JsPath
-import viewmodels.PlatformOperatorSummaryViewModel
+import builders.EmailsSentResultBuilder.anEmailsSentResult
+import models.pageviews.PlatformOperatorRemovedViewModel
 
-case object PlatformOperatorDeletedQuery extends Gettable[PlatformOperatorSummaryViewModel] with Settable[PlatformOperatorSummaryViewModel] {
+object PlatformOperatorRemovedViewModelBuilder {
 
-  override def path: JsPath = JsPath \ "platformOperatorDeletedInfo"
+  val aPlatformOperatorRemovedViewModel: PlatformOperatorRemovedViewModel = PlatformOperatorRemovedViewModel(
+    userEmail = "default.user.email@example.com",
+    operatorId = "default-operator-id",
+    poBusinessName = "default-po-name",
+    poEmail = "default.po.email@example.com",
+    emailsSentResult = anEmailsSentResult
+  )
 }

--- a/test-utils/builders/PlatformOperatorUpdatedViewModelBuilder.scala
+++ b/test-utils/builders/PlatformOperatorUpdatedViewModelBuilder.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package builders
+
+import builders.EmailsSentResultBuilder.anEmailsSentResult
+import models.pageviews.PlatformOperatorUpdatedViewModel
+
+object PlatformOperatorUpdatedViewModelBuilder {
+
+  val aPlatformOperatorUpdatedViewModel: PlatformOperatorUpdatedViewModel = PlatformOperatorUpdatedViewModel(
+    userEmail = "default.user.email@example.com",
+    operatorId = "default-operator-id",
+    poBusinessName = "default-po-name",
+    poEmail = "default.po.email@example.com",
+    emailsSentResult = anEmailsSentResult
+  )
+}

--- a/test/controllers/update/PlatformOperatorRemovedControllerSpec.scala
+++ b/test/controllers/update/PlatformOperatorRemovedControllerSpec.scala
@@ -97,7 +97,6 @@ class PlatformOperatorRemovedControllerSpec extends SpecBase with MockitoSugar {
 
         val emailsSentResult = EmailsSentResult(userEmailSent = false, poEmailSent = None)
         val baseAnswers = emptyUserAnswers.set(PlatformOperatorDeletedQuery, aPlatformOperatorSummaryViewModel).success.value
-          .set(SentRemovedPlatformOperatorEmailQuery, emailsSentResult).success.value
 
         val application = applicationBuilder(userAnswers = Some(baseAnswers)).overrides(
           inject.bind[SubscriptionConnector].toInstance(mockConnector)).build

--- a/test/controllers/update/PlatformOperatorRemovedControllerSpec.scala
+++ b/test/controllers/update/PlatformOperatorRemovedControllerSpec.scala
@@ -17,29 +17,105 @@
 package controllers.update
 
 import base.SpecBase
+import builders.PlatformOperatorSummaryViewModelBuilder.aPlatformOperatorSummaryViewModel
+import builders.SubscriptionInfoBuilder.aSubscriptionInfo
+import connectors.SubscriptionConnector
+import models.email.EmailsSentResult
+import models.pageviews.PlatformOperatorRemovedViewModel
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.inject
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import queries.PlatformOperatorDeletedQuery
+import queries.{PlatformOperatorDeletedQuery, SentRemovedPlatformOperatorEmailQuery}
 import views.html.update.PlatformOperatorRemovedView
 
-class PlatformOperatorRemovedControllerSpec extends SpecBase {
+import scala.concurrent.Future
+
+class PlatformOperatorRemovedControllerSpec extends SpecBase with MockitoSugar {
+
+  private val mockConnector = mock[SubscriptionConnector]
 
   "PlatformOperatorRemoved Controller" - {
 
-    "must return OK and the correct view for a GET" in {
+    "must return OK and the correct view for a GET" - {
+      "for different emails" in {
+        when(mockConnector.getSubscriptionInfo(any())) thenReturn Future.successful(aSubscriptionInfo)
 
-      val updatedAnswers = emptyUserAnswers.set(PlatformOperatorDeletedQuery, "businessName").success.value
-      val application = applicationBuilder(userAnswers = Some(updatedAnswers)).build()
+        val emailsSentResult = EmailsSentResult(userEmailSent = true, Some(true))
+        val baseAnswers = emptyUserAnswers.set(PlatformOperatorDeletedQuery, aPlatformOperatorSummaryViewModel).success.value
+          .set(SentRemovedPlatformOperatorEmailQuery, emailsSentResult).success.value
 
-      running(application) {
-        val request = FakeRequest(GET, routes.PlatformOperatorRemovedController.onPageLoad(operatorId).url)
+        val application = applicationBuilder(userAnswers = Some(baseAnswers)).overrides(
+          inject.bind[SubscriptionConnector].toInstance(mockConnector)).build()
 
-        val result = route(application, request).value
+        running(application) {
+          val request = FakeRequest(GET, routes.PlatformOperatorRemovedController.onPageLoad(operatorId).url)
+          val result = route(application, request).value
+          val view = application.injector.instanceOf[PlatformOperatorRemovedView]
 
-        val view = application.injector.instanceOf[PlatformOperatorRemovedView]
+          val viewModel = PlatformOperatorRemovedViewModel(aSubscriptionInfo, aPlatformOperatorSummaryViewModel,
+            emailsSentResult)
+          status(result) mustEqual OK
+          contentAsString(result) mustEqual view(viewModel)(request, messages(application)).toString
+          contentAsString(result) must include(
+            messages(application)("platformOperatorRemoved.p1.1.two.emails", viewModel.userEmail, viewModel.poEmail)
+          )
+        }
+      }
 
-        status(result) mustEqual OK
-        contentAsString(result) mustEqual view(operatorId, "businessName")(request, messages(application)).toString
+      "for same emails" in {
+        when(mockConnector.getSubscriptionInfo(any())) thenReturn Future.successful(aSubscriptionInfo)
+
+        val emailsSentResult = EmailsSentResult(userEmailSent = true, poEmailSent = None)
+        val baseAnswers = emptyUserAnswers.set(PlatformOperatorDeletedQuery, aPlatformOperatorSummaryViewModel).success.value
+          .set(SentRemovedPlatformOperatorEmailQuery, emailsSentResult).success.value
+
+        val application = applicationBuilder(userAnswers = Some(baseAnswers)).overrides(
+          inject.bind[SubscriptionConnector].toInstance(mockConnector)).build
+
+        running(application) {
+          val request = FakeRequest(GET, routes.PlatformOperatorRemovedController.onPageLoad(operatorId).url)
+          val result = route(application, request).value
+          val view = application.injector.instanceOf[PlatformOperatorRemovedView]
+
+          val platformOperatorViewModel = aPlatformOperatorSummaryViewModel.copy(poPrimaryContactEmail = aSubscriptionInfo.primaryContact.email)
+          val viewModel = PlatformOperatorRemovedViewModel(aSubscriptionInfo, platformOperatorViewModel,
+            emailsSentResult)
+
+          status(result) mustEqual OK
+          contentAsString(result) mustEqual view(viewModel)(request, messages(application)).toString
+          contentAsString(result) must include(
+            messages(application)("platformOperatorRemoved.p1.1.one.email", viewModel.userEmail, viewModel.poEmail)
+          )
+        }
+      }
+
+      "when no emails were sent" in {
+        when(mockConnector.getSubscriptionInfo(any())) thenReturn Future.successful(aSubscriptionInfo)
+
+        val emailsSentResult = EmailsSentResult(userEmailSent = false, poEmailSent = None)
+        val baseAnswers = emptyUserAnswers.set(PlatformOperatorDeletedQuery, aPlatformOperatorSummaryViewModel).success.value
+          .set(SentRemovedPlatformOperatorEmailQuery, emailsSentResult).success.value
+
+        val application = applicationBuilder(userAnswers = Some(baseAnswers)).overrides(
+          inject.bind[SubscriptionConnector].toInstance(mockConnector)).build
+
+        running(application) {
+          val request = FakeRequest(GET, routes.PlatformOperatorRemovedController.onPageLoad(operatorId).url)
+          val result = route(application, request).value
+          val view = application.injector.instanceOf[PlatformOperatorRemovedView]
+
+          val viewModel = PlatformOperatorRemovedViewModel(aSubscriptionInfo, aPlatformOperatorSummaryViewModel,
+            emailsSentResult)
+
+          status(result) mustEqual OK
+          contentAsString(result) mustEqual view(viewModel)(request, messages(application)).toString
+          contentAsString(result) must include(
+            messages(application)("platformOperatorRemoved.emailNotSent.warning", viewModel.userEmail, viewModel.poEmail)
+          )
+        }
       }
     }
   }

--- a/test/controllers/update/PlatformOperatorUpdatedControllerSpec.scala
+++ b/test/controllers/update/PlatformOperatorUpdatedControllerSpec.scala
@@ -17,32 +17,106 @@
 package controllers.update
 
 import base.SpecBase
-import pages.update.BusinessNamePage
+import builders.PlatformOperatorSummaryViewModelBuilder.aPlatformOperatorSummaryViewModel
+import builders.SubscriptionInfoBuilder.aSubscriptionInfo
+import connectors.SubscriptionConnector
+import models.email.EmailsSentResult
+import models.pageviews.PlatformOperatorUpdatedViewModel
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.update.{BusinessNamePage, PrimaryContactEmailPage}
+import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import viewmodels.PlatformOperatorSummaryViewModel
+import queries.SentUpdatedPlatformOperatorEmailQuery
 import views.html.update.PlatformOperatorUpdatedView
 
-class PlatformOperatorUpdatedControllerSpec extends SpecBase {
+import scala.concurrent.Future
+
+class PlatformOperatorUpdatedControllerSpec extends SpecBase with MockitoSugar {
+
+  private val mockConnector = mock[SubscriptionConnector]
 
   "PlatformOperatorUpdated Controller" - {
 
-    "must return OK and the correct view for a GET" in {
+    "must return OK and the correct view for a GET" - {
+      "for different emails" in {
+        when(mockConnector.getSubscriptionInfo(any())) thenReturn Future.successful(aSubscriptionInfo)
 
-      val viewModel = PlatformOperatorSummaryViewModel("id", "name", "email")
-      val baseAnswers = emptyUserAnswers.set(BusinessNamePage, "name").success.value
+        val emailsSentResult = EmailsSentResult(userEmailSent = true, Some(true))
+        val baseAnswers = emptyUserAnswers.set(BusinessNamePage, "default-operator-name").success.value
+          .set(PrimaryContactEmailPage, "default.contact@example.com").success.value
+          .set(SentUpdatedPlatformOperatorEmailQuery, emailsSentResult).success.value
 
-      val application = applicationBuilder(userAnswers = Some(baseAnswers)).build()
+        val application = applicationBuilder(userAnswers = Some(baseAnswers)).overrides(
+          bind[SubscriptionConnector].toInstance(mockConnector)).build
 
-      running(application) {
-        val request = FakeRequest(GET, routes.PlatformOperatorUpdatedController.onPageLoad(operatorId).url)
+        running(application) {
+          val request = FakeRequest(GET, routes.PlatformOperatorUpdatedController.onPageLoad(operatorId).url)
+          val result = route(application, request).value
+          val view = application.injector.instanceOf[PlatformOperatorUpdatedView]
 
-        val result = route(application, request).value
+          status(result) mustEqual OK
+          val viewModel = PlatformOperatorUpdatedViewModel(aSubscriptionInfo, aPlatformOperatorSummaryViewModel,
+            emailsSentResult)
+          contentAsString(result) mustEqual view(viewModel)(request, messages(application)).toString
+          contentAsString(result) must include(
+            messages(application)("platformOperatorUpdated.p1.1.two.emails", viewModel.userEmail, viewModel.poEmail))
+        }
+      }
 
-        val view = application.injector.instanceOf[PlatformOperatorUpdatedView]
+      "for same emails" in {
+        when(mockConnector.getSubscriptionInfo(any())) thenReturn Future.successful(aSubscriptionInfo)
 
-        status(result) mustEqual OK
-        contentAsString(result) mustEqual view(operatorId, viewModel)(request, messages(application)).toString
+        val emailsSentResult = EmailsSentResult(userEmailSent = true, poEmailSent = None)
+        val baseAnswers = emptyUserAnswers.set(BusinessNamePage, "default-operator-name").success.value
+          .set(PrimaryContactEmailPage, "default.email@example.com").success.value
+          .set(SentUpdatedPlatformOperatorEmailQuery, emailsSentResult).success.value
+
+        val application = applicationBuilder(userAnswers = Some(baseAnswers)).overrides(
+          bind[SubscriptionConnector].toInstance(mockConnector)).build
+
+        running(application) {
+          val request = FakeRequest(GET, routes.PlatformOperatorUpdatedController.onPageLoad(operatorId).url)
+          val result = route(application, request).value
+          val view = application.injector.instanceOf[PlatformOperatorUpdatedView]
+
+          val platformOperatorViewModel = aPlatformOperatorSummaryViewModel.copy(poPrimaryContactEmail = aSubscriptionInfo.primaryContact.email)
+          val viewModel = PlatformOperatorUpdatedViewModel(aSubscriptionInfo, platformOperatorViewModel, emailsSentResult)
+
+          status(result) mustEqual OK
+          contentAsString(result) mustEqual view(viewModel)(request, messages(application)).toString
+          contentAsString(result) must include(
+            messages(application)("platformOperatorUpdated.p1.1.one.email", viewModel.userEmail, viewModel.poEmail)
+          )
+        }
+      }
+
+      "when no emails were sent is false" in {
+        when(mockConnector.getSubscriptionInfo(any())) thenReturn Future.successful(aSubscriptionInfo)
+
+        val emailsSentResult = EmailsSentResult(userEmailSent = false, poEmailSent = None)
+        val baseAnswers = emptyUserAnswers.set(BusinessNamePage, "default-operator-name").success.value
+          .set(PrimaryContactEmailPage, "default.email@example.com").success.value
+          .set(SentUpdatedPlatformOperatorEmailQuery, emailsSentResult).success.value
+
+        val application = applicationBuilder(userAnswers = Some(baseAnswers)).overrides(
+          bind[SubscriptionConnector].toInstance(mockConnector)).build
+
+        running(application) {
+          val request = FakeRequest(GET, routes.PlatformOperatorUpdatedController.onPageLoad(operatorId).url)
+          val result = route(application, request).value
+          val view = application.injector.instanceOf[PlatformOperatorUpdatedView]
+
+          val viewModel = PlatformOperatorUpdatedViewModel(aSubscriptionInfo, aPlatformOperatorSummaryViewModel, emailsSentResult)
+
+          status(result) mustEqual OK
+          contentAsString(result) mustEqual view(viewModel)(request, messages(application)).toString
+          contentAsString(result) must include(
+            messages(application)("platformOperatorUpdated.emailNotSent.warning")
+          )
+        }
       }
     }
   }

--- a/test/controllers/update/PlatformOperatorUpdatedControllerSpec.scala
+++ b/test/controllers/update/PlatformOperatorUpdatedControllerSpec.scala
@@ -93,13 +93,12 @@ class PlatformOperatorUpdatedControllerSpec extends SpecBase with MockitoSugar {
         }
       }
 
-      "when no emails were sent is false" in {
+      "when no emails were sent" in {
         when(mockConnector.getSubscriptionInfo(any())) thenReturn Future.successful(aSubscriptionInfo)
 
         val emailsSentResult = EmailsSentResult(userEmailSent = false, poEmailSent = None)
         val baseAnswers = emptyUserAnswers.set(BusinessNamePage, "default-operator-name").success.value
           .set(PrimaryContactEmailPage, "default.email@example.com").success.value
-          .set(SentUpdatedPlatformOperatorEmailQuery, emailsSentResult).success.value
 
         val application = applicationBuilder(userAnswers = Some(baseAnswers)).overrides(
           bind[SubscriptionConnector].toInstance(mockConnector)).build
@@ -116,6 +115,18 @@ class PlatformOperatorUpdatedControllerSpec extends SpecBase with MockitoSugar {
           contentAsString(result) must include(
             messages(application)("platformOperatorUpdated.emailNotSent.warning")
           )
+        }
+      }
+
+      "redirects to JourneyRecovery page when subscriptionInfo fails" in {
+
+        val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build
+
+        running(application) {
+          val request = FakeRequest(GET, routes.PlatformOperatorUpdatedController.onPageLoad(operatorId).url)
+          val result = route(application, request).value
+
+          status(result) mustEqual SEE_OTHER
         }
       }
     }

--- a/test/models/pageviews/PlatformOperatorRemovedViewModelSpec.scala
+++ b/test/models/pageviews/PlatformOperatorRemovedViewModelSpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.pageviews
+
+import builders.EmailsSentResultBuilder.anEmailsSentResult
+import builders.PlatformOperatorRemovedViewModelBuilder.aPlatformOperatorRemovedViewModel
+import builders.PlatformOperatorSummaryViewModelBuilder.aPlatformOperatorSummaryViewModel
+import builders.SubscriptionInfoBuilder.aSubscriptionInfo
+import models.email.EmailsSentResult
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+
+class PlatformOperatorRemovedViewModelSpec extends AnyFreeSpec with Matchers {
+
+  ".apply(...)" - {
+    "must create correct object" in {
+      PlatformOperatorRemovedViewModel.apply(
+        subscriptionInfo = aSubscriptionInfo,
+        platformOperatorSummaryViewModel = aPlatformOperatorSummaryViewModel,
+        emailsSentResult = anEmailsSentResult,
+      ) mustBe PlatformOperatorRemovedViewModel(
+        userEmail = aSubscriptionInfo.primaryContact.email,
+        operatorId = aPlatformOperatorSummaryViewModel.operatorId,
+        poBusinessName = aPlatformOperatorSummaryViewModel.operatorName,
+        poEmail = aPlatformOperatorSummaryViewModel.poPrimaryContactEmail,
+        emailsSentResult = anEmailsSentResult
+      )
+    }
+  }
+
+  ".sentEmails(...)" - {
+    "must return empty list when" - {
+      "user and po emails failed" in {
+        val underTest = aPlatformOperatorRemovedViewModel.copy(emailsSentResult = EmailsSentResult(userEmailSent = false, Some(false)))
+
+        underTest.sentEmails mustBe Seq.empty
+      }
+
+      "user email failed and no po email" in {
+        val underTest = aPlatformOperatorRemovedViewModel.copy(emailsSentResult = EmailsSentResult(userEmailSent = false, None))
+
+        underTest.sentEmails mustBe Seq.empty
+      }
+    }
+
+    "must return user email only when" - {
+      "user email sent and no po email info" in {
+        val underTest = aPlatformOperatorRemovedViewModel.copy(emailsSentResult = EmailsSentResult(userEmailSent = true, None))
+
+        underTest.sentEmails mustBe Seq(aPlatformOperatorRemovedViewModel.userEmail)
+      }
+
+      "user email sent and no po email failed" in {
+        val underTest = aPlatformOperatorRemovedViewModel.copy(emailsSentResult = EmailsSentResult(userEmailSent = true, Some(false)))
+
+        underTest.sentEmails mustBe Seq(aPlatformOperatorRemovedViewModel.userEmail)
+      }
+    }
+
+    "must return po email only when" - {
+      "user email failed and po email sent" in {
+        val underTest = aPlatformOperatorRemovedViewModel.copy(emailsSentResult = EmailsSentResult(userEmailSent = false, Some(true)))
+
+        underTest.sentEmails mustBe Seq(aPlatformOperatorRemovedViewModel.poEmail)
+      }
+    }
+
+    "must return user an po emails when both succeed" in {
+      val underTest = aPlatformOperatorRemovedViewModel.copy(emailsSentResult = EmailsSentResult(userEmailSent = true, Some(true)))
+
+      underTest.sentEmails mustBe Seq(aPlatformOperatorRemovedViewModel.userEmail, aPlatformOperatorRemovedViewModel.poEmail)
+    }
+  }
+}

--- a/test/models/pageviews/PlatformOperatorUpdatedViewModelSpec.scala
+++ b/test/models/pageviews/PlatformOperatorUpdatedViewModelSpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.pageviews
+
+import builders.EmailsSentResultBuilder.anEmailsSentResult
+import builders.PlatformOperatorSummaryViewModelBuilder.aPlatformOperatorSummaryViewModel
+import builders.PlatformOperatorUpdatedViewModelBuilder.aPlatformOperatorUpdatedViewModel
+import builders.SubscriptionInfoBuilder.aSubscriptionInfo
+import models.email.EmailsSentResult
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+
+class PlatformOperatorUpdatedViewModelSpec extends AnyFreeSpec with Matchers {
+
+  ".apply(...)" - {
+    "must create correct object" in {
+      PlatformOperatorUpdatedViewModel.apply(
+        subscriptionInfo = aSubscriptionInfo,
+        platformOperatorSummaryViewModel = aPlatformOperatorSummaryViewModel,
+        emailsSentResult = anEmailsSentResult,
+      ) mustBe PlatformOperatorUpdatedViewModel(
+        userEmail = aSubscriptionInfo.primaryContact.email,
+        operatorId = aPlatformOperatorSummaryViewModel.operatorId,
+        poBusinessName = aPlatformOperatorSummaryViewModel.operatorName,
+        poEmail = aPlatformOperatorSummaryViewModel.poPrimaryContactEmail,
+        emailsSentResult = anEmailsSentResult
+      )
+    }
+  }
+
+  ".sentEmails(...)" - {
+    "must return empty list when" - {
+      "user and po emails failed" in {
+        val underTest = aPlatformOperatorUpdatedViewModel.copy(emailsSentResult = EmailsSentResult(userEmailSent = false, Some(false)))
+
+        underTest.sentEmails mustBe Seq.empty
+      }
+
+      "user email failed and no po email" in {
+        val underTest = aPlatformOperatorUpdatedViewModel.copy(emailsSentResult = EmailsSentResult(userEmailSent = false, None))
+
+        underTest.sentEmails mustBe Seq.empty
+      }
+    }
+
+    "must return user email only when" - {
+      "user email sent and no po email info" in {
+        val underTest = aPlatformOperatorUpdatedViewModel.copy(emailsSentResult = EmailsSentResult(userEmailSent = true, None))
+
+        underTest.sentEmails mustBe Seq(aPlatformOperatorUpdatedViewModel.userEmail)
+      }
+
+      "user email sent and no po email failed" in {
+        val underTest = aPlatformOperatorUpdatedViewModel.copy(emailsSentResult = EmailsSentResult(userEmailSent = true, Some(false)))
+
+        underTest.sentEmails mustBe Seq(aPlatformOperatorUpdatedViewModel.userEmail)
+      }
+    }
+
+    "must return po email only when" - {
+      "user email failed and po email sent" in {
+        val underTest = aPlatformOperatorUpdatedViewModel.copy(emailsSentResult = EmailsSentResult(userEmailSent = false, Some(true)))
+
+        underTest.sentEmails mustBe Seq(aPlatformOperatorUpdatedViewModel.poEmail)
+      }
+    }
+
+    "must return user an po emails when both succeed" in {
+      val underTest = aPlatformOperatorUpdatedViewModel.copy(emailsSentResult = EmailsSentResult(userEmailSent = true, Some(true)))
+
+      underTest.sentEmails mustBe Seq(aPlatformOperatorUpdatedViewModel.userEmail, aPlatformOperatorUpdatedViewModel.poEmail)
+    }
+  }
+}


### PR DESCRIPTION
[ODPR-1773](https://jira.tools.tax.service.gov.uk/browse/ODPR-1773)
- Adds email sent/not sent content at end of Update & Remove PO journey (similar to what happens in add PO journey)
- Content is dynamic depending on:
1. Shows both emails if the PO email and user email (from sub journey) are different
2. Shows just the one email if emails are different
3. Shows warning text if email was not sent